### PR TITLE
Install aaa package in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap@v2
         with:
+          GAP_PKGS_TO_CLONE: "aaa"
           GAP_PKGS_TO_BUILD: "datastructures aaa digraphs io profiling orb"
           GAPBRANCH: ${{ matrix.gap-branch }}
       - uses: gap-actions/build-pkg@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ name: CI
 on:
   - push
   - pull_request
+  - workflow_dispatch
 
 jobs:
   # The CI test job


### PR DESCRIPTION
Check it out!  This is how you install a package in the GAP Github actions.

For future reference, <https://github.com/gap-actions/build-pkg> and other stuff at <https://github.com/gap-actions/> is where all this is stored.